### PR TITLE
modify character encode in knowledge_methods.rb

### DIFF
--- a/lib/docomoru/knowledge_methods.rb
+++ b/lib/docomoru/knowledge_methods.rb
@@ -4,7 +4,7 @@ module Docomoru
 
     def create_knowledge(message, params = {}, headers = {})
       get(
-        "#{PATH}?#{default_query_string}&q=#{message}",
+        "#{PATH}?#{default_query_string}&q=#{CGI.escape(message)}",
         params,
         headers,
       )


### PR DESCRIPTION
hi, `docomoru` is very beautiful product, thanks :)

btw, by Ruby version (2.3.0 or later?), it must be necessary for Japanese URI to be encoded with `CGI.escape` method.

this method is not implemented in current `knowledge_methods.rb`, so if we send Japanese message, `URI must be ascii only` error occurs.

```
/home/takiya/.rbenv/versions/2.5.0/lib/ruby/2.5.0/uri/rfc3986_parser.rb:21:in `split': URI must be ascii only "/knowledgeQA/v1/ask?APIKEY=foobar&q=\u4ECA\u65E5\u306F\u4F55\u66DC\u65E5\uFF1F" (URI::InvalidURIError)
```

so I append `CGI.escape` method at its statement :-)

note: `create_dialogue` method is unrelated to this because of POST method